### PR TITLE
Introduce sentinel error ErrMultipleRows

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -36,3 +36,14 @@ func NonFatalError(err error) bool {
 		return false
 	}
 }
+
+// Used by SelectOne to signal that there were multiple values returned when
+// expecting only one
+type ErrMultipleRows struct {
+	Query string
+	Args  []interface{}
+}
+
+func (e ErrMultipleRows) Error() string {
+	return fmt.Sprintf("gorp: multiple rows returned for: %s - %v", e.Query, e.Args)
+}

--- a/select.go
+++ b/select.go
@@ -131,7 +131,7 @@ func SelectOne(m *DbMap, e SqlExecutor, holder interface{}, query string, args .
 		if list != nil && len(list) > 0 { // FIXME: invert if/else
 			// check for multiple rows
 			if len(list) > 1 {
-				return fmt.Errorf("gorp: multiple rows returned for: %s - %v", query, args)
+				return ErrMultipleRows{Query: query, Args: args}
 			}
 
 			// Initialize if nil


### PR DESCRIPTION
This can be consumed by a consumer to know when the error case is when
there are multiple rows when expecting only one. It maintains the same
error string, but can be caught in an error type switch in tests.