### PR TITLE
MAIN-31443: introduce redshift dialect

### DIFF
--- a/dialect_redshift.go
+++ b/dialect_redshift.go
@@ -1,0 +1,19 @@
+package gorp
+
+type RedshiftDialect struct {
+	PostgresDialect
+}
+
+func (d RedshiftDialect) InsertAutoIncrToTarget(exec SqlExecutor, insertSql string, target interface{}, params ...interface{}) error {
+	rows, err := exec.Query(insertSql, params...)
+	defer rows.Close()
+	return err
+}
+
+func (d RedshiftDialect) AutoIncrBindValue() string {
+	return ""
+}
+
+func (d RedshiftDialect) AutoIncrInsertSuffix(col *ColumnMap) string {
+	return ""
+}

--- a/dialect_redshift.go
+++ b/dialect_redshift.go
@@ -6,8 +6,10 @@ type RedshiftDialect struct {
 
 func (d RedshiftDialect) InsertAutoIncrToTarget(exec SqlExecutor, insertSql string, _ interface{}, params ...interface{}) error {
 	rows, err := exec.Query(insertSql, params...)
-	defer rows.Close()
-	return err
+	if err != nil {
+		return err
+	}
+	return rows.Close()
 }
 
 func (d RedshiftDialect) AutoIncrBindValue() string {

--- a/dialect_redshift.go
+++ b/dialect_redshift.go
@@ -4,16 +4,19 @@ type RedshiftDialect struct {
 	PostgresDialect
 }
 
-func (d RedshiftDialect) InsertAutoIncrToTarget(exec SqlExecutor, insertSql string, target interface{}, params ...interface{}) error {
+func (d RedshiftDialect) InsertAutoIncrToTarget(exec SqlExecutor, insertSql string, _ interface{}, params ...interface{}) error {
 	rows, err := exec.Query(insertSql, params...)
 	defer rows.Close()
 	return err
 }
 
 func (d RedshiftDialect) AutoIncrBindValue() string {
+	// returning an empty string here makes gorp skip adding this column to the INSERT SQL
+	// this is needed because Redshift does not allow specifying values for IDENTITY columns
 	return ""
 }
 
 func (d RedshiftDialect) AutoIncrInsertSuffix(col *ColumnMap) string {
+	// Redshift has no support for RETURNING values after an insert
 	return ""
 }


### PR DESCRIPTION
This adds support for using gorp with redshift. This is the same as the
postgres dialect but with a few changes to support redshift.

* Don't add RETURNING to Insert SQL as redshift does not support it
* Return empty string for auto increment columns so gorp does not try
to insert a value. Redshift forbids this.
* After inserting the record don't scan and set the ID back to the target
object