### PR TITLE
MAIN-32888 - update schema when changing mapping

### DIFF
--- a/db.go
+++ b/db.go
@@ -176,7 +176,7 @@ func (m *DbMap) AddTableWithNameAndSchema(i interface{}, schema string, name str
 	}
 
 	// check if we have a table for this type already
-	// if so, update the name and return the existing pointer
+	// if so, update the name/schema, clear the cached queries, and return the existing pointer
 	for i := range m.tables {
 		table := m.tables[i]
 		if table.gotype == t {

--- a/db.go
+++ b/db.go
@@ -181,6 +181,8 @@ func (m *DbMap) AddTableWithNameAndSchema(i interface{}, schema string, name str
 		table := m.tables[i]
 		if table.gotype == t {
 			table.TableName = name
+			table.SchemaName = schema
+			table.ResetSql()
 			return table
 		}
 	}


### PR DESCRIPTION
AddTableWithNameAndSchema supports being called for structs that are already in
the table map. When that happens, it updates the mapping in place. While it was
correctly updating the table name, it wasn't updating the schema name, and also
wasn't clearing out the cached queries. Both of those things need to happen for
a clean update of an existing mapping.